### PR TITLE
Add alerts partial to allParticipants view.

### DIFF
--- a/views/partials/alerts.ejs
+++ b/views/partials/alerts.ejs
@@ -1,0 +1,7 @@
+<% if (typeof alerts !== "undefined") { %>
+  <% alerts.forEach((alert) => { %>
+    <div class="alert alert-<%= alert.type %>" role="alert">
+      <%= alert.message %> 
+    </div>
+  <% }) %>
+<% } %>

--- a/views/participants/allParticipants.ejs
+++ b/views/participants/allParticipants.ejs
@@ -6,6 +6,7 @@
   <body>
     <%- include('../partials/header', {title: "All Participants"}) %>
     <div class="container content">
+      <%- include('../partials/alerts') %>
       <table id="participantsTable" class="table">
         <thead>
           <tr>


### PR DESCRIPTION
Add alert partial
Add alert partial to allParticipants view

The alert partial should be included at the beginning of the "container content" div.
The alerts can be used by adding the alerts variable to the render.  The alerts variable should be an array of dictionaries, each dictionary should have a "type" key for the type of alert (success, danger, etc) and a "message" key for the string to be displayed in the alert.  If no alerts variable is passed in with the render or it is empty, no alerts will be displayed and there is no error.